### PR TITLE
version 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.4.0] - 2024-08-24
+
+### Added
+
+- livenessProbe (tcp)
+- tolerations: wait 10s when node is unavaialble
+
 ## [2.3.0] - 2024-08-05
 
 ### Changed

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.0
+version: 2.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -69,6 +69,13 @@ spec:
             failureThreshold: 30
             periodSeconds: 10
           {{- end }}
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.livenessProbe.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          {{- end }}
       {{ if .Values.image.registrySecret }}
       imagePullSecrets:
       - name: {{ .Values.image.registrySecret }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -76,6 +76,17 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 2
           {{- end }}
+      {{- if .Values.livenessProbe }}
+      tolerations:
+        - key: "node.kubernetes.io/unreachable"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 10
+        - key: "node.kubernetes.io/not-ready"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 10
+      {{- end }}
       {{ if .Values.image.registrySecret }}
       imagePullSecrets:
       - name: {{ .Values.image.registrySecret }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
             tcpSocket:
               port: {{ .Values.livenessProbe.port }}
             initialDelaySeconds: 10
-            periodSeconds: 10
+            periodSeconds: 2
           {{- end }}
       {{ if .Values.image.registrySecret }}
       imagePullSecrets:

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -9,6 +9,9 @@ metadata:
   namespace: default
 spec:
   type: {{ .type }}
+  {{- if .loadBalancerIP }}
+  loadBalancerIP: {{ .loadBalancerIP }}
+  {{- end }}
   ports:
     - name: {{ .name }}
       protocol: {{ .protocol }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -37,3 +37,4 @@ deployNotifications:
   enabled: false
   image: ""
 nodeSelector: {}
+livenessProbe: {}


### PR DESCRIPTION
# Liveness Probe
Ability to enable liveness probe on specified in configuration port. Liveness probes are TCP type
## Hardcoded setup
```yaml
initialDelaySeconds: 10
  periodSeconds: 2
```
# Tolerations
When certain cluster node is not available
```
node.kubernetes.io/unreachable
node.kubernetes.io/not-ready
```
Pod should be killed and deployed on healthy node after 10 sec.