### PR TITLE
9 common shared storage path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.5.0] - 2024-09-01
+
+### Added
+
+- common rootdir on shared storage
+
 ## [2.4.0] - 2024-08-24
 
 ### Added

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.0
+version: 2.5.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -107,7 +107,11 @@ spec:
           {{- if .Values.volumes.type.nfs }}
           nfs:
             server: {{ .Values.volumes.type.nfs.server }}
+            {{- if .Values.volumes.rootDir }}
+            path: {{ .Values.volumes.type.nfs.path }}/{{ .Values.volumes.rootDir }}
+            {{- else }}
             path: {{ .Values.volumes.type.nfs.path }}/{{ .Release.Name }}
+            {{- end }}
             readOnly: false
           {{- else }}
           persistentVolumeClaim:

--- a/chart/templates/initWebsiteDir.yaml
+++ b/chart/templates/initWebsiteDir.yaml
@@ -32,7 +32,11 @@ spec:
             {{- range .Values.volumes.mountPath }}
             {{- $dirmap := regexSplit ":" . -1 -}}
             {{- $dir := slice $dirmap 0 1 | first -}}
+            {{- if .Values.volumes.rootDir -}}
+            {{- $dirs_to_create = printf "%s %s/%s/%s" $dirs_to_create "/storage" $.Values.volumes.rootDir $dir }}
+            {{- else }}
             {{- $dirs_to_create = printf "%s %s/%s/%s" $dirs_to_create "/storage" $.Release.Name $dir }}
+            {{- end }}
             {{- end }}
             value: {{ $dirs_to_create }}
           - name: OWNERSHIP

--- a/chart/templates/initWebsiteDir.yaml
+++ b/chart/templates/initWebsiteDir.yaml
@@ -32,7 +32,7 @@ spec:
             {{- range .Values.volumes.mountPath }}
             {{- $dirmap := regexSplit ":" . -1 -}}
             {{- $dir := slice $dirmap 0 1 | first -}}
-            {{- if .Values.volumes.rootDir -}}
+            {{- if $.Values.volumes.rootDir -}}
             {{- $dirs_to_create = printf "%s %s/%s/%s" $dirs_to_create "/storage" $.Values.volumes.rootDir $dir }}
             {{- else }}
             {{- $dirs_to_create = printf "%s %s/%s/%s" $dirs_to_create "/storage" $.Release.Name $dir }}

--- a/chart/templates/initWebsiteDir.yaml
+++ b/chart/templates/initWebsiteDir.yaml
@@ -48,7 +48,7 @@ spec:
           args:
             - -c
             - >-
-                mkdir -p $(WEBSITE_DIRS);
+                mkdir -p $(WEBSITE_DIRS); chown -R $(OWNERSHIP) $(WEBSITE_DIRS);
       nodeSelector:
         {{- with .Values.nodeSelector }}
         {{- toYaml . | nindent 8 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -25,6 +25,7 @@ ingress:
   tls: {}
 volumes:
   enabled: false
+  rootDir: ""
   mountPath: []
   ownership: ""
   type:


### PR DESCRIPTION
## Use case 
In some cases  there's a need to share common shared storage space among more than one app or different app instances (i.e. server and worker instances). To solve this problem a new option was introduced: **rootDir**
This change was introduced in #9 issue.

## How to use

rootDir configuration

```yaml
values:
  volumes:
    rootDir: common
```
This parameter is optional, so when no rootDir is specified, than HelmRelease name will be used to create parent folder on shared storage.
