### PR TITLE
7 livenessprobe configuration causing restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.6.0] - 2024-10-19
+
+### Changed
+
+- Startup and Liveness probes are moved to HelmRelease file
+- initWebsiteDir hook: create website dir when it does not exist
+
 ## [2.5.0] - 2024-09-01
 
 ### Added

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.0
+version: 2.6.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -61,20 +61,17 @@ spec:
               containerPort: {{.targetPort }}
               protocol: TCP
             {{- end }}
-          {{- if .Values.startupProbes.enabled }}
+          {{- if .Values.startupProbe }}
           startupProbe:
-            httpGet:
-              path: /
-              port: {{ .Values.startupProbes.port | default 80 }}
-            failureThreshold: 30
-            periodSeconds: 10
+            {{- with .Values.startupProbe }}
+            {{- toYaml . | nindent 13 }}
+            {{- end }}
           {{- end }}
           {{- if .Values.livenessProbe }}
           livenessProbe:
-            tcpSocket:
-              port: {{ .Values.livenessProbe.port }}
-            initialDelaySeconds: 10
-            periodSeconds: 2
+            {{- with .Values.livenessProbe }}
+            {{- toYaml . | nindent 13 }}
+            {{- end }}
           {{- end }}
       {{- if .Values.livenessProbe }}
       tolerations:

--- a/chart/templates/initWebsiteDir.yaml
+++ b/chart/templates/initWebsiteDir.yaml
@@ -48,7 +48,10 @@ spec:
           args:
             - -c
             - >-
-                mkdir -p $(WEBSITE_DIRS); chown -R $(OWNERSHIP) $(WEBSITE_DIRS);
+                if [! -d $(WEBSITE_DIRS) ]; then
+                  mkdir -p $(WEBSITE_DIRS); 
+                  chown -R $(OWNERSHIP) $(WEBSITE_DIRS);
+                endif
       nodeSelector:
         {{- with .Values.nodeSelector }}
         {{- toYaml . | nindent 8 }}

--- a/chart/templates/initWebsiteDir.yaml
+++ b/chart/templates/initWebsiteDir.yaml
@@ -51,7 +51,7 @@ spec:
                 if [! -d $(WEBSITE_DIRS) ]; then
                   mkdir -p $(WEBSITE_DIRS); 
                   chown -R $(OWNERSHIP) $(WEBSITE_DIRS);
-                endif
+                fi
       nodeSelector:
         {{- with .Values.nodeSelector }}
         {{- toYaml . | nindent 8 }}

--- a/chart/test_values.yaml
+++ b/chart/test_values.yaml
@@ -51,3 +51,14 @@ ingress:
       servicePort: 80
     - name: registry.lab.angrybits.pl
       servicePort: 5050
+startupProbe:
+  httpGet:
+    path: /
+    port: 666
+  failureThreshold: 30
+  periodSeconds: 10
+livenessProbe:
+  tcpSocket:
+    port: 666
+  initialDelaySeconds: 10
+  periodSeconds: 2

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -25,17 +25,13 @@ ingress:
   tls: {}
 volumes:
   enabled: false
-  rootDir: ""
   mountPath: []
   ownership: ""
   type:
     nfs:
       server: lab-storage.lan
       path: /volume1/storagelab
-startupProbes:
-  enabled: true
 deployNotifications:
   enabled: false
   image: ""
 nodeSelector: {}
-livenessProbe: {}


### PR DESCRIPTION
## Probes (liveness and startup)

This change eliminates problem #7  when some applications could not be started because of too narrow probes configuration. Problem was addressed by moving `startupProbe` and `livenessProbe` sections directly to HelmRelease files of particular applications. Helmchart imports this configuration to create deployment objects.

### Example
```yaml
startupProbe:
  httpGet:
    path: /
    port: 666
  failureThreshold: 30
  periodSeconds: 10
livenessProbe:
  tcpSocket:
    port: 666
  initialDelaySeconds: 10
  periodSeconds: 2
```
More info on: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/